### PR TITLE
Upgrade surrealdb docker image to default to 1.0.0

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -10,5 +10,5 @@ var (
 	//
 	// If you would like to use some other version, you can update this variable
 	// to point to the image you want to use.
-	SurrealDBTag = "1.0.0-beta.9-20230402"
+	SurrealDBTag = "1.0.0"
 )

--- a/helpers.go
+++ b/helpers.go
@@ -40,7 +40,7 @@ func NewSurrealDBRaw(t testing.TB) (string, func()) {
 	runOpt := &dockertest.RunOptions{
 		Repository: SurrealDBRepo,
 		Tag:        SurrealDBTag,
-		Cmd:        []string{"start", "-p", "root"},
+		Cmd:        []string{"start", "--auth", "--user", "root", "--pass", "root", "memory"},
 
 		ExposedPorts: []string{targetPort},
 		PortBindings: map[docker.Port][]docker.PortBinding{

--- a/unmarshall.go
+++ b/unmarshall.go
@@ -96,7 +96,7 @@ func handleAsRawQuery(input interface{}) (interface{}, error) {
 	}
 
 	if raw.Status != "OK" {
-		return nil, fmt.Errorf("%s: %s", raw.Status, raw.Detail)
+		return nil, fmt.Errorf("%s: %s", raw.Status, raw.Result)
 	}
 
 	return raw.Result, nil


### PR DESCRIPTION
- Upgrade base Docker image tag to `1.0.0`
- Update the error message handling following the server implementation change
- Update startup arguments to match with the new format expected with 1.0.0 release