### PR TITLE
Remove noisy printf which was meant for debug

### DIFF
--- a/unmarshall.go
+++ b/unmarshall.go
@@ -17,7 +17,8 @@ func handleInterfaces[I any](input interface{}) ([]I, error) {
 	var errs []error
 	inputs, ok := input.([]interface{})
 	if !ok {
-		fmt.Printf("  data\n    %+v\n", input)
+		// Only used for debugging
+		// fmt.Printf("  data\n    %+v\n", input)
 		return handleInput[I](input)
 	}
 


### PR DESCRIPTION
I may need to adjust the logic to ensure this debug logging is made available in
some specific cases, but for now, as the unmarshal logic is only meant to be
something temporary, simply disabling the debug fmt.Printf.